### PR TITLE
Save synchronized views in MetadataStorage

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -6,6 +6,7 @@ namespace Kenny1911\DoctrineViewsSync\Console;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ConnectionRegistry;
+use Kenny1911\DoctrineViewsSync\Metadata\MetadataStorage;
 use Kenny1911\DoctrineViewsSync\Persistence\SingleConnectionRegistry;
 use Kenny1911\DoctrineViewsSync\Psr\Container\MapContainer;
 use Kenny1911\DoctrineViewsSync\ViewsProvider;
@@ -24,13 +25,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class BaseCommand extends Command
 {
-    /**
-     * @param iterable<non-empty-string> $ignoredViews
-     */
     final public function __construct(
         private readonly ConnectionRegistry $connectionRegistry,
         private readonly ContainerInterface $viewsProviderLocator,
-        private readonly iterable $ignoredViews = [],
+        private readonly ContainerInterface $metadataStorageLocator,
         ?string $name = null,
     ) {
         parent::__construct($name);
@@ -39,6 +37,7 @@ abstract class BaseCommand extends Command
     final public static function createByConnection(
         Connection $connection,
         ViewsProvider $viewsProvider,
+        MetadataStorage $metadataStorage,
         ?string $name = null,
     ): self {
         $connectionRegistry = new SingleConnectionRegistry($connection);
@@ -46,6 +45,7 @@ abstract class BaseCommand extends Command
         return new static(
             connectionRegistry: $connectionRegistry,
             viewsProviderLocator: new MapContainer([$connectionRegistry->getDefaultConnectionName() => $viewsProvider]),
+            metadataStorageLocator: new MapContainer([$connectionRegistry->getDefaultConnectionName() => $metadataStorage]),
             name: $name,
         );
     }
@@ -80,9 +80,16 @@ abstract class BaseCommand extends Command
             throw new \LogicException(\sprintf('Invalid views provider. Expected %s, got %s.', ViewsProvider::class, get_debug_type($viewsProvider)));
         }
 
+        $metadataStorage = $this->metadataStorageLocator->get($connectionName);
+
+        if (false === $metadataStorage instanceof MetadataStorage) {
+            throw new \LogicException(\sprintf('Invalid metadata storage. Expected %s, got %s.', MetadataStorage::class, get_debug_type($viewsProvider)));
+        }
+
         $viewsSync = new ViewsSync(
             connection: $connection,
             viewsProvider: $viewsProvider,
+            metadataStorage: $metadataStorage,
             output: $output,
         );
 

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -4,16 +4,8 @@ declare(strict_types=1);
 
 namespace Kenny1911\DoctrineViewsSync\Console;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\Persistence\ConnectionRegistry;
-use Kenny1911\DoctrineViewsSync\Metadata\MetadataStorage;
-use Kenny1911\DoctrineViewsSync\Persistence\SingleConnectionRegistry;
-use Kenny1911\DoctrineViewsSync\Psr\Container\MapContainer;
-use Kenny1911\DoctrineViewsSync\ViewsProvider;
 use Kenny1911\DoctrineViewsSync\ViewsSync;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
+use Kenny1911\DoctrineViewsSync\ViewsSyncFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -26,28 +18,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class BaseCommand extends Command
 {
     final public function __construct(
-        private readonly ConnectionRegistry $connectionRegistry,
-        private readonly ContainerInterface $viewsProviderLocator,
-        private readonly ContainerInterface $metadataStorageLocator,
+        private readonly ViewsSyncFactory $factory,
         ?string $name = null,
     ) {
         parent::__construct($name);
-    }
-
-    final public static function createByConnection(
-        Connection $connection,
-        ViewsProvider $viewsProvider,
-        MetadataStorage $metadataStorage,
-        ?string $name = null,
-    ): self {
-        $connectionRegistry = new SingleConnectionRegistry($connection);
-
-        return new static(
-            connectionRegistry: $connectionRegistry,
-            viewsProviderLocator: new MapContainer([$connectionRegistry->getDefaultConnectionName() => $viewsProvider]),
-            metadataStorageLocator: new MapContainer([$connectionRegistry->getDefaultConnectionName() => $metadataStorage]),
-            name: $name,
-        );
     }
 
     #[\Override]
@@ -60,38 +34,11 @@ abstract class BaseCommand extends Command
         );
     }
 
-    /**
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     */
     #[\Override]
     final protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $connectionName = $input->hasArgument('conn') ? (string) $input->getArgument('conn') : $this->connectionRegistry->getDefaultConnectionName();
-        $connection = $this->connectionRegistry->getConnection($connectionName);
-
-        if (false === $connection instanceof Connection) {
-            throw new \LogicException(\sprintf('Invalid connection instance. Expected %s, got %s.', Connection::class, get_debug_type($connection)));
-        }
-
-        $viewsProvider = $this->viewsProviderLocator->get($connectionName);
-
-        if (false === $viewsProvider instanceof ViewsProvider) {
-            throw new \LogicException(\sprintf('Invalid views provider. Expected %s, got %s.', ViewsProvider::class, get_debug_type($viewsProvider)));
-        }
-
-        $metadataStorage = $this->metadataStorageLocator->get($connectionName);
-
-        if (false === $metadataStorage instanceof MetadataStorage) {
-            throw new \LogicException(\sprintf('Invalid metadata storage. Expected %s, got %s.', MetadataStorage::class, get_debug_type($viewsProvider)));
-        }
-
-        $viewsSync = new ViewsSync(
-            connection: $connection,
-            viewsProvider: $viewsProvider,
-            metadataStorage: $metadataStorage,
-            output: $output,
-        );
+        $connectionName = $input->hasArgument('conn') ? (string) $input->getArgument('conn') : null;
+        $viewsSync = $this->factory->create($connectionName);
 
         $this->doExecute($viewsSync);
 

--- a/src/Metadata/MetadataStorage.php
+++ b/src/Metadata/MetadataStorage.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\DoctrineViewsSync\Metadata;
+
+use Doctrine\DBAL\Schema\View;
+
+/**
+ * @api
+ */
+interface MetadataStorage
+{
+    /**
+     * @return list<View>
+     */
+    public function loadViews(): array;
+
+    /**
+     * @param list<View> $views
+     */
+    public function saveViews(array $views): void;
+}

--- a/src/Metadata/TableMetadataStorage.php
+++ b/src/Metadata/TableMetadataStorage.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\DoctrineViewsSync\Metadata;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\View;
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * @api
+ */
+final class TableMetadataStorage implements MetadataStorage
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $table = 'doctrine_views_sync_metadata',
+    ) {}
+
+    public function configureSchema(Schema $schema): void
+    {
+        $table = $schema->createTable($this->table);
+        $table->addColumn('view_name', Types::STRING);
+        $table->addColumn('data', Types::TEXT)->setNotnull(true);
+        $table->setPrimaryKey(['view_name']);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[\Override]
+    public function loadViews(): array
+    {
+        /** @var list<View> $views */
+        $views = [];
+
+        /** @var array{view_name: string, data: string} $data */
+        foreach ($this->connection->executeQuery("SELECT * FROM {$this->table}")->iterateAssociative() as $data) {
+            try {
+                $views[] = self::unserialize($data['data']);
+            } catch (\Throwable) {
+            }
+        }
+
+        return $views;
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[\Override]
+    public function saveViews(array $views): void
+    {
+        $this->connection->executeStatement("DELETE FROM {$this->table}");
+
+        foreach ($views as $view) {
+            $this->connection->executeStatement(
+                sql: "INSERT INTO {$this->table} VALUES (:viewName, :data)",
+                params: [
+                    'viewName' => $view->getName(),
+                    'data' => self::serialize($view),
+                ],
+            );
+        }
+    }
+
+    private static function serialize(View $view): string
+    {
+        return base64_encode(serialize($view));
+    }
+
+    private static function unserialize(string $data): View
+    {
+        $view = unserialize((string) base64_decode($data, true));
+
+        if ($view instanceof View) {
+            return $view;
+        }
+
+        throw new \RuntimeException('Can not unserialize view.');
+    }
+}

--- a/src/ViewsProvider/MetadataStorageViewsProvider.php
+++ b/src/ViewsProvider/MetadataStorageViewsProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\DoctrineViewsSync\ViewsProvider;
+
+use Kenny1911\DoctrineViewsSync\Metadata\MetadataStorage;
+use Kenny1911\DoctrineViewsSync\ViewsProvider;
+
+/**
+ * @api
+ */
+final class MetadataStorageViewsProvider implements ViewsProvider
+{
+    public function __construct(
+        private readonly MetadataStorage $metadataStorage,
+    ) {}
+
+    #[\Override]
+    public function getViews(): iterable
+    {
+        return $this->metadataStorage->loadViews();
+    }
+}

--- a/src/ViewsSync.php
+++ b/src/ViewsSync.php
@@ -7,7 +7,8 @@ namespace Kenny1911\DoctrineViewsSync;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Kenny1911\DoctrineViewsSync\ViewsProvider\ReverseViewsProvider;
+use Kenny1911\DoctrineViewsSync\Metadata\MetadataStorage;
+use Kenny1911\DoctrineViewsSync\ViewsProvider\MetadataStorageViewsProvider;
 use Kenny1911\DoctrineViewsSync\ViewsProvider\UniqueViewsProvider;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,12 +30,13 @@ final class ViewsSync
     public function __construct(
         private readonly Connection $connection,
         ViewsProvider $viewsProvider,
+        private readonly MetadataStorage $metadataStorage,
         private readonly OutputInterface $output = new NullOutput(),
     ) {
         /** @noinspection PhpUnhandledExceptionInspection */
         $this->schemaManager = $this->connection->createSchemaManager();
         $this->viewsProvider = new UniqueViewsProvider($viewsProvider);
-        $this->reverseViewsProvider = new ReverseViewsProvider($this->viewsProvider);
+        $this->reverseViewsProvider = new MetadataStorageViewsProvider($this->metadataStorage);
     }
 
     public function drop(): void
@@ -60,10 +62,14 @@ final class ViewsSync
      */
     private function doDrop(): void
     {
-        foreach ($this->reverseViewsProvider->getViews() as $view) {
+        $views = $this->reverseViewsProvider->getViews();
+
+        foreach ($views as $view) {
             $this->schemaManager->dropView($view->getQuotedName($this->connection->getDatabasePlatform()));
             $this->output->writeln(\sprintf('Drop view "%s".', $view->getName()));
         }
+
+        $this->metadataStorage->saveViews([]);
     }
 
     /**
@@ -71,10 +77,14 @@ final class ViewsSync
      */
     private function doCreate(): void
     {
-        foreach ($this->viewsProvider->getViews() as $view) {
+        $views = iterator_to_array($this->viewsProvider->getViews(), false);
+
+        foreach ($views as $view) {
             $this->schemaManager->createView($view);
             $this->output->writeln(\sprintf('Create view "%s".', $view->getName()));
         }
+
+        $this->metadataStorage->saveViews($views);
     }
 
     /**

--- a/src/ViewsSyncFactory.php
+++ b/src/ViewsSyncFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\DoctrineViewsSync;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ConnectionRegistry;
+use Kenny1911\DoctrineViewsSync\Metadata\MetadataStorage;
+use Kenny1911\DoctrineViewsSync\Persistence\SingleConnectionRegistry;
+use Kenny1911\DoctrineViewsSync\Psr\Container\MapContainer;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @api
+ */
+final class ViewsSyncFactory
+{
+    /** @var array<string, ViewsSync> */
+    private array $viewsSync = [];
+
+    public function __construct(
+        private readonly ConnectionRegistry $connectionRegistry,
+        private readonly ContainerInterface $viewsProviderLocator,
+        private readonly ContainerInterface $metadataStorageLocator,
+    ) {}
+
+    public static function fromSingleConnection(
+        Connection $connection,
+        ViewsProvider $viewsProvider,
+        MetadataStorage $metadataStorage,
+    ): self {
+        $connectionRegistry = new SingleConnectionRegistry($connection);
+
+        return new self(
+            connectionRegistry: $connectionRegistry,
+            viewsProviderLocator: new MapContainer([$connectionRegistry->getDefaultConnectionName() => $viewsProvider]),
+            metadataStorageLocator: new MapContainer([$connectionRegistry->getDefaultConnectionName() => $metadataStorage]),
+        );
+    }
+
+    public function create(?string $connectionName = null, OutputInterface $output = new NullOutput()): ViewsSync
+    {
+        $connection = $this->connectionRegistry->getConnection($connectionName);
+
+        if (isset($this->viewsSync[$connectionName])) {
+            return $this->viewsSync[$connectionName];
+        }
+
+        $connectionName ??= $this->connectionRegistry->getDefaultConnectionName();
+
+        if (false === $connection instanceof Connection) {
+            throw new \LogicException(\sprintf('Invalid connection instance. Expected %s, got %s.', Connection::class, get_debug_type($connection)));
+        }
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $viewsProvider = $this->viewsProviderLocator->get($connectionName);
+
+        if (false === $viewsProvider instanceof ViewsProvider) {
+            throw new \LogicException(\sprintf('Invalid views provider. Expected %s, got %s.', ViewsProvider::class, get_debug_type($viewsProvider)));
+        }
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $metadataStorage = $this->metadataStorageLocator->get($connectionName);
+
+        if (false === $metadataStorage instanceof MetadataStorage) {
+            throw new \LogicException(\sprintf('Invalid metadata storage. Expected %s, got %s.', MetadataStorage::class, get_debug_type($viewsProvider)));
+        }
+
+        return $this->viewsSync[$connectionName] = new ViewsSync(
+            connection: $connection,
+            viewsProvider: $viewsProvider,
+            metadataStorage: $metadataStorage,
+            output: $output,
+        );
+    }
+}

--- a/tests/ViewsSyncTest.php
+++ b/tests/ViewsSyncTest.php
@@ -7,6 +7,9 @@ namespace Kenny1911\DoctrineViewsSync\Tests;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\View;
+use Kenny1911\DoctrineViewsSync\Metadata\MetadataStorage;
+use Kenny1911\DoctrineViewsSync\Metadata\TableMetadataStorage;
+use Kenny1911\DoctrineViewsSync\ViewsProvider;
 use Kenny1911\DoctrineViewsSync\ViewsProvider\CallableViewsProvider;
 use Kenny1911\DoctrineViewsSync\ViewsProvider\DuplicateView;
 use Kenny1911\DoctrineViewsSync\ViewsSync;
@@ -26,6 +29,8 @@ final class ViewsSyncTest extends TestCase
 
     private Connection $connection;
 
+    private MetadataStorage $metadataStorage;
+
     /**
      * @throws Exception
      */
@@ -41,6 +46,11 @@ final class ViewsSyncTest extends TestCase
         $usersTable->addColumn('password', 'string')->setNotnull(true);
         $usersTable->addColumn('enabled', 'boolean')->setNotnull(true);
         $usersTable->setPrimaryKey(['id']);
+
+        $this->metadataStorage = new TableMetadataStorage(
+            connection: $this->connection,
+        );
+        $this->metadataStorage->configureSchema($dbManager->schema);
 
         $dbManager->migrate();
 
@@ -64,8 +74,7 @@ final class ViewsSyncTest extends TestCase
      */
     public function test(): void
     {
-        $sync = new ViewsSync(
-            connection: $this->connection,
+        $sync = $this->createSync(
             viewsProvider: new CallableViewsProvider(static fn() => yield new View(
                 name: 'users_enabled',
                 sql: 'SELECT id, username FROM users WHERE enabled = true',
@@ -103,8 +112,7 @@ final class ViewsSyncTest extends TestCase
         unset($sync, $result);
 
         // Check sync view
-        $sync2 = new ViewsSync(
-            connection: $this->connection,
+        $sync2 = $this->createSync(
             viewsProvider: new CallableViewsProvider(static fn() => yield new View(
                 name: 'users_enabled',
                 sql: 'SELECT username FROM users WHERE enabled = true',
@@ -131,8 +139,7 @@ final class ViewsSyncTest extends TestCase
     {
         self::expectException(DuplicateView::class);
 
-        $sync = new ViewsSync(
-            connection: $this->connection,
+        $sync = $this->createSync(
             viewsProvider: new CallableViewsProvider(static function () {
                 yield new View(
                     name: 'users_enabled',
@@ -149,6 +156,15 @@ final class ViewsSyncTest extends TestCase
         $sync->create();
     }
 
+    private function createSync(ViewsProvider $viewsProvider): ViewsSync
+    {
+        return new ViewsSync(
+            connection: $this->connection,
+            viewsProvider: $viewsProvider,
+            metadataStorage: $this->metadataStorage,
+        );
+    }
+
     /**
      * @return list<View>
      *
@@ -156,17 +172,7 @@ final class ViewsSyncTest extends TestCase
      */
     private function getViews(): array
     {
-        $views = [];
-
-        foreach ($this->connection->createSchemaManager()->listViews() as $view) {
-            if (\in_array($view->getNamespaceName(), ['information_schema', 'pg_catalog', 'pg_toast'], true)) {
-                continue;
-            }
-
-            $views[] = $view;
-        }
-
-        return $views;
+        return $this->metadataStorage->loadViews();
     }
 
     private function getViewName(View $view): string


### PR DESCRIPTION
- MetadataStorage - is storage with information about all synchronized views. It must be used for drop all previously created views.
- TableMetadataStorage - is implementation of MetadataStorage, that used database.
- MetadataStorageViewsProvider is ViewsProvider implementation, that used MetadataStorage.
- ViewsSync used MetadataStorage instead ReverseViewsProvider.
- Refactor BaseCommand.