### PR TITLE
Constrain doctrine/dbal version to <4.3

### DIFF
--- a/bin/check-multiply-versions.sh
+++ b/bin/check-multiply-versions.sh
@@ -3,7 +3,7 @@
 WORKING_DIR="$(dirname $(dirname $(realpath $0)))"
 cd "${WORKING_DIR}"
 
-for doctrine_dbal_ver in '^3.0' '^4.0'; do
+for doctrine_dbal_ver in '^3.0' '^4.0 <4.3'; do
   for doctrine_persistence in '^3.1' '^4.0'; do
     for symfony_console_version in '^5.4' '^6.0' '^7.0'; do
       composer install &&

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/dbal": "^3.0 || ^4.0",
+        "doctrine/dbal": "^3.0 || ^4.0 <4.3",
         "doctrine/persistence": "^3.1|^4.0",
         "psr/container": "^2.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0"


### PR DESCRIPTION
There are changes in the new doctrine/dbal 4.3.0 version, that break backward compatibility.