### PR TITLE
Topological sort for create and drop views

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": "^8.1",
         "doctrine/dbal": "^3.0 || ^4.0 <4.3",
         "doctrine/persistence": "^3.1|^4.0",
+        "marcj/topsort": "^2.0",
         "psr/container": "^2.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0"
     },

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\DoctrineViewsSync\Schema;
+
+/**
+ * @api
+ */
+final class View extends \Doctrine\DBAL\Schema\View
+{
+    /**
+     * @param list<string> $dependencies List of dependencies views names
+     */
+    public function __construct(
+        string $name,
+        string $sql,
+        public readonly array $dependencies = [],
+    ) {
+        parent::__construct($name, $sql);
+    }
+}

--- a/src/ViewsProvider/ReverseViewsProvider.php
+++ b/src/ViewsProvider/ReverseViewsProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Kenny1911\DoctrineViewsSync\ViewsProvider;
 
-use Doctrine\DBAL\Schema\View;
 use Kenny1911\DoctrineViewsSync\ViewsProvider;
 use function Kenny1911\DoctrineViewsSync\iterator_to_array;
 
@@ -14,9 +13,6 @@ use function Kenny1911\DoctrineViewsSync\iterator_to_array;
  */
 final class ReverseViewsProvider implements ViewsProvider
 {
-    /** @var array<View>|null */
-    private ?array $reversedViews = null;
-
     public function __construct(
         private readonly ViewsProvider $inner,
     ) {}
@@ -24,12 +20,6 @@ final class ReverseViewsProvider implements ViewsProvider
     #[\Override]
     public function getViews(): iterable
     {
-        if (null !== $this->reversedViews) {
-            return $this->reversedViews;
-        }
-
-        $this->reversedViews = $reversedViews = array_reverse(iterator_to_array($this->inner->getViews()));
-
-        return $reversedViews;
+        return array_reverse(iterator_to_array($this->inner->getViews(), false));
     }
 }

--- a/src/ViewsProvider/TopologicalSortViewsProvider.php
+++ b/src/ViewsProvider/TopologicalSortViewsProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\DoctrineViewsSync\ViewsProvider;
+
+use Doctrine\DBAL\Schema\View;
+use Kenny1911\DoctrineViewsSync\Schema\View as DepsView;
+use Kenny1911\DoctrineViewsSync\ViewsProvider;
+use MJS\TopSort\CircularDependencyException;
+use MJS\TopSort\ElementNotFoundException;
+use MJS\TopSort\Implementations\FixedArraySort;
+
+/**
+ * @internal
+ * @psalm-internal Kenny1911\DoctrineViewsSync
+ */
+final class TopologicalSortViewsProvider implements ViewsProvider
+{
+    public function __construct(
+        private readonly ViewsProvider $inner,
+    ) {}
+
+    /**
+     * @throws CircularDependencyException
+     * @throws ElementNotFoundException
+     */
+    #[\Override]
+    public function getViews(): iterable
+    {
+        $sorter = new FixedArraySort();
+        /** @var array<string, View> $views */
+        $viewsMap = [];
+
+        foreach ($this->inner->getViews() as $view) {
+            $viewsMap[$view->getName()] = $view;
+            $sorter->add($view->getName(), $view instanceof DepsView ? $view->dependencies : []);
+        }
+
+        /** @var list<View> $sortedViews */
+        $sortedViews = [];
+
+        foreach ($sorter->sort() as $viewName) {
+            $sortedViews[] = $viewsMap[$viewName] ?? throw new \RuntimeException(\sprintf('View with name "%s" not exists.', $viewName));
+        }
+
+        return $sortedViews;
+    }
+}

--- a/src/ViewsSync.php
+++ b/src/ViewsSync.php
@@ -9,6 +9,8 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Kenny1911\DoctrineViewsSync\Metadata\MetadataStorage;
 use Kenny1911\DoctrineViewsSync\ViewsProvider\MetadataStorageViewsProvider;
+use Kenny1911\DoctrineViewsSync\ViewsProvider\ReverseViewsProvider;
+use Kenny1911\DoctrineViewsSync\ViewsProvider\TopologicalSortViewsProvider;
 use Kenny1911\DoctrineViewsSync\ViewsProvider\UniqueViewsProvider;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -35,8 +37,14 @@ final class ViewsSync
     ) {
         /** @noinspection PhpUnhandledExceptionInspection */
         $this->schemaManager = $this->connection->createSchemaManager();
-        $this->viewsProvider = new UniqueViewsProvider($viewsProvider);
-        $this->reverseViewsProvider = new MetadataStorageViewsProvider($this->metadataStorage);
+        $this->viewsProvider = new TopologicalSortViewsProvider(
+            new UniqueViewsProvider($viewsProvider),
+        );
+        $this->reverseViewsProvider = new ReverseViewsProvider(
+            new TopologicalSortViewsProvider(
+                new MetadataStorageViewsProvider($this->metadataStorage),
+            ),
+        );
     }
 
     public function drop(): void

--- a/tests/ViewsProvider/TopologicalSortViewsProviderTest.php
+++ b/tests/ViewsProvider/TopologicalSortViewsProviderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kenny1911\DoctrineViewsSync\Tests\ViewsProvider;
+
+use Doctrine\DBAL\Schema\View as DoctrineView;
+use Kenny1911\DoctrineViewsSync\Schema\View;
+use Kenny1911\DoctrineViewsSync\ViewsProvider\CallableViewsProvider;
+use Kenny1911\DoctrineViewsSync\ViewsProvider\TopologicalSortViewsProvider;
+use MJS\TopSort\CircularDependencyException;
+use MJS\TopSort\ElementNotFoundException;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @psalm-internal Kenny1911\DoctrineViewsSync\Tests\ViewsProvider
+ */
+final class TopologicalSortViewsProviderTest extends TestCase
+{
+    /**
+     * @param list<View> $views
+     * @param list<string> $expectedViewsNames
+     *
+     * @throws CircularDependencyException
+     * @throws ElementNotFoundException
+     */
+    #[TestWith(
+        data: [
+            'views' => [],
+            'expectedViewsNames' => [],
+        ],
+        name: 'empty',
+    )]
+    #[TestWith(
+        data: [
+            'views' => [
+                new DoctrineView('foo', 'SELECT 1'),
+                new DoctrineView('bar', 'SELECT 1'),
+            ],
+            'expectedViewsNames' => ['foo', 'bar'],
+        ],
+        name: 'simple',
+    )]
+    #[TestWith(
+        data: [
+            'views' => [
+                new View('foo', 'SELECT 1', ['bar']),
+                new DoctrineView('bar', 'SELECT 1'),
+            ],
+            'expectedViewsNames' => ['bar', 'foo'],
+        ],
+        name: 'depends',
+    )]
+    #[TestWith(
+        data: [
+            'views' => [
+                new View('foo', 'SELECT 1', ['bar', 'qux']),
+                new View('bar', 'SELECT 1'),
+                new View('baz', 'SELECT 1', ['qux']),
+                new View('qux', 'SELECT 1', ['bar']),
+            ],
+            'expectedViewsNames' => ['bar', 'qux', 'foo', 'baz'],
+        ],
+        name: 'complex',
+    )]
+    public function test(array $views, array $expectedViewsNames): void
+    {
+        $viewsProvider = new TopologicalSortViewsProvider(new CallableViewsProvider(static fn() => $views));
+        $actualViewsNames = [];
+
+        foreach ($viewsProvider->getViews() as $view) {
+            $actualViewsNames[] = $view->getName();
+        }
+
+        self::assertSame($expectedViewsNames, $actualViewsNames);
+    }
+
+    /**
+     * @throws CircularDependencyException
+     */
+    public function testThrowElementNotFoundException(): void
+    {
+        self::expectException(ElementNotFoundException::class);
+
+        $views = [
+            new View('foo', 'SELECT 1', ['bar']),
+        ];
+
+        $viewsProvider = new TopologicalSortViewsProvider(new CallableViewsProvider(static fn() => $views));
+        $viewsProvider->getViews();
+    }
+
+    /**
+     * @throws ElementNotFoundException
+     */
+    public function testThrowCircularDependencyException(): void
+    {
+        self::expectException(CircularDependencyException::class);
+
+        $views = [
+            new View('foo', 'SELECT 1', ['bar']),
+            new View('bar', 'SELECT 1', ['foo']),
+        ];
+
+        $viewsProvider = new TopologicalSortViewsProvider(new CallableViewsProvider(static fn() => $views));
+        $viewsProvider->getViews();
+    }
+}

--- a/tests/ViewsSyncTest.php
+++ b/tests/ViewsSyncTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\View;
 use Kenny1911\DoctrineViewsSync\Metadata\MetadataStorage;
 use Kenny1911\DoctrineViewsSync\Metadata\TableMetadataStorage;
+use Kenny1911\DoctrineViewsSync\Schema\View as DependView;
 use Kenny1911\DoctrineViewsSync\ViewsProvider;
 use Kenny1911\DoctrineViewsSync\ViewsProvider\CallableViewsProvider;
 use Kenny1911\DoctrineViewsSync\ViewsProvider\DuplicateView;
@@ -156,6 +157,37 @@ final class ViewsSyncTest extends TestCase
         $sync->create();
     }
 
+    /**
+     * @throws Exception
+     */
+    public function testDependViews(): void
+    {
+        $sync = $this->createSync(
+            viewsProvider: new CallableViewsProvider(static function () {
+                // View users_enabled_view depends on other view users_view, but it is earlier in the list
+                yield new DependView('users_enabled_view', 'SELECT id, username FROM users_view WHERE enabled = true', ['users_view']);
+                yield new View('users_view', 'SELECT id, username, enabled FROM users');
+            }),
+        );
+
+        self::assertSame([], $this->getViewsNames());
+
+        $sync->drop();
+        self::assertSame([], $this->getViewsNames());
+
+        $sync->create();
+        self::assertSame(['users_view', 'users_enabled_view'], $this->getViewsNames());
+
+        $sync->drop();
+        self::assertSame([], $this->getViewsNames());
+
+        $sync->create();
+        self::assertSame(['users_view', 'users_enabled_view'], $this->getViewsNames());
+
+        $sync->drop();
+        self::assertSame([], $this->getViewsNames());
+    }
+
     private function createSync(ViewsProvider $viewsProvider): ViewsSync
     {
         return new ViewsSync(
@@ -173,6 +205,16 @@ final class ViewsSyncTest extends TestCase
     private function getViews(): array
     {
         return $this->metadataStorage->loadViews();
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @throws Exception
+     */
+    private function getViewsNames(): array
+    {
+        return array_map(fn(View $v) => $this->getViewName($v), $this->getViews());
     }
 
     private function getViewName(View $view): string


### PR DESCRIPTION
Create `\Kenny1911\DoctrineViewsSync\Schema\View`, that extends default doctrine schema View and supports dependencies for views.

Use topological Views sort in. It implements in decorator TopologicalSortViewsProvider and use `marcj/topsort`.